### PR TITLE
Modify Travis to fail builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ xcode_sdk: iphonesimulator11.0
 before_install:
 - brew install tailor
 script:
-- tailor PPal --except=trailing-whitespace
-- tailor PPalTests --except=trailing-whitespace
+- tailor PPal --except=trailing-whitespace --max-severity=error
+- tailor PPalTests --except=trailing-whitespace --max-severity=error

--- a/PPal/AppDelegate.swift
+++ b/PPal/AppDelegate.swift
@@ -43,4 +43,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
 }
-

--- a/PPal/ViewController.swift
+++ b/PPal/ViewController.swift
@@ -22,4 +22,3 @@ class ViewController: UIViewController {
 
 
 }
-

--- a/PPalTests/DatabaseTest.swift
+++ b/PPalTests/DatabaseTest.swift
@@ -324,4 +324,5 @@ class DatabaseTest: XCTestCase {
         XCTAssertTrue(peopleFromDatabase.count == 0, "The profile was not deleted properly!")
         
     }
+    
 }

--- a/PPalTests/DatabaseTest.swift
+++ b/PPalTests/DatabaseTest.swift
@@ -182,7 +182,7 @@ class DatabaseTest: XCTestCase {
             XCTAssertTrue(personInfo.address == "\(indexOfPerson) Street", "The address does not match!")
             XCTAssertFalse(personInfo.hasHouseKeys, "The person is not supposed to have keys!")
             for label in labelArray {
-                XCTAssertTrue(personInfo.labels.contains(label!),"The label is supposed to be in this array, but it's not!")
+                XCTAssertTrue(personInfo.labels.contains(label!), "The label is supposed to be in this array, but it's not!")
             }
         }
         


### PR DESCRIPTION
From now on, code must follow coding standards (with the exception of trailing whitespaces), or Travis will fail the build and display a `build failing` image.